### PR TITLE
visibility of explain tab depends on response content only

### DIFF
--- a/src/views/Home.vue
+++ b/src/views/Home.vue
@@ -2,10 +2,13 @@
   <div class="home">
     <login-box v-if="!loggedIn"></login-box>
     <div v-if="loggedIn" class="chatbot-wrapper"
-         :class="{expanded:explainTabClicked&&explainChecked,'expanded-left':backgroundTabClicked}">
+         :class="{expanded:explainTabClicked&&(explanations.length > 0),
+                 'expanded-left':backgroundTabClicked}">
       <h3 class="title">Hello, {{$store.state.nickName}}</h3>
       <span class="button explain"
-            :class="{expanded:explainTabClicked&&explainChecked,disabled:!explainChecked}"
+            :class="{disabled:!(explanations.length > 0),
+                     expanded:explainTabClicked&&(explanations.length > 0)
+                     }"
             @click="tabButtonClicked('explain')">Explanation</span>
       <span class="button background" :class="{expanded:backgroundTabClicked}"
             @click="tabButtonClicked('background')">Background</span>
@@ -31,7 +34,7 @@
       </div>
     </div>
     <div v-if="loggedIn"
-         class="explanation-window" :class="{expanded: explainTabClicked&&explainChecked}">
+         class="explanation-window" :class="{expanded: explainTabClicked&&(explanations.length > 0)}">
       <div class='background section'>
         <h2 class='section-title'>Background</h2>
         <accordion v-for="(entity,index) in background"
@@ -110,7 +113,6 @@ export default {
         this.explainTabClicked = false;
         this.backgroundTabClicked = false;
       }
-
     },
     setMessageGradient(message) {
       const redRGB = {


### PR DESCRIPTION
the visibility and disabled state of the explain tab should only depend on the availability of explanation data